### PR TITLE
Increase Content Width & Improve Blockquote styling 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 #baseurl: "" # the subpath of your site, e.g. /blog
 #url: "" # the base hostname & protocol for your site, e.g. http://example.com
 search_enabled: true
-color_scheme: "light"
+color_scheme: apim
 remote_theme: pmarsceill/just-the-docs
 search:
   # Split pages into sections that can be searched individually

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 #baseurl: "" # the subpath of your site, e.g. /blog
 #url: "" # the base hostname & protocol for your site, e.g. http://example.com
 search_enabled: true
+# Custom scheme implemented as per these directions: https://github.com/pmarsceill/just-the-docs/blob/master/docs/customization.md#custom-schemes
 color_scheme: apim
 remote_theme: pmarsceill/just-the-docs
 search:

--- a/_sass/color_schemes/apim.scss
+++ b/_sass/color_schemes/apim.scss
@@ -1,2 +1,14 @@
 // Custom scheme implemented as per these directions: https://github.com/pmarsceill/just-the-docs/blob/master/docs/customization.md#custom-schemes
-$content-width: 1024px
+$content-width: 1024px;
+
+// Make the blockquote visually more noticeable than the default Just the Docs styling provides
+blockquote {
+  background: $grey-lt-000;
+  border-left: 8px solid $blue-200;
+  margin: 10px 10px 20px 20px;
+  padding: 0.5em 10px;
+
+  p {
+    margin: 0;
+  }
+}

--- a/_sass/color_schemes/apim.scss
+++ b/_sass/color_schemes/apim.scss
@@ -1,0 +1,1 @@
+$content-width: 1024px

--- a/_sass/color_schemes/apim.scss
+++ b/_sass/color_schemes/apim.scss
@@ -1,1 +1,2 @@
+// Custom scheme implemented as per these directions: https://github.com/pmarsceill/just-the-docs/blob/master/docs/customization.md#custom-schemes
 $content-width: 1024px


### PR DESCRIPTION
# Widened the content view

## Before
![image](https://user-images.githubusercontent.com/84809797/151396660-d6396d84-c2c4-46c6-9ae3-f483927c2a70.png)

## After
Text in images is much more readable now and no longer fuzzy.

![image](https://user-images.githubusercontent.com/84809797/151396757-5d1698e4-2bc3-42d5-84c7-bb364a6a56c7.png)

# Improved blockquote styling

## Before
![image](https://user-images.githubusercontent.com/84809797/151396783-fcc84466-fb3c-439a-8c22-887a8c43a40d.png)

## After
The vertical blue line and other styling now draws better attention to blockquotes.

![image](https://user-images.githubusercontent.com/84809797/151396863-e2a9de89-821f-4723-812a-de5806369216.png)

Closes #54 