### PR TITLE
Revert "Bump commonmarker from 0.23.9 to 0.23.10"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.10)
+    commonmarker (0.23.9)
     concurrent-ruby (1.2.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)


### PR DESCRIPTION
Reverts Azure/apim-lab#122