### PR TITLE
Fixed internal documentation links in the contribution guide

### DIFF
--- a/apim-lab/11-contributing/contributing-11-1-contribution-guide.md
+++ b/apim-lab/11-contributing/contributing-11-1-contribution-guide.md
@@ -9,9 +9,9 @@ If you'd like to contribute to this workshop, please read the following guidelin
 
 # What Can I Do?
 
-- [Submit an issue or suggestion](2-Submit-issue-suggestion.md)
-- [Minor update or fix to an existing challenge and adding a new challenge](3-minor-update-fix.md)
-- [Run the github page locally with Github Codespaces](4-github-codespaces.md)
+- [Submit an issue or suggestion](contributing-11-2-Submit-issue-suggestion.md)
+- [Minor update or fix to an existing challenge and adding a new challenge](contributing-11-3-minor-update-fix.md)
+- [Run the github page locally with Github Codespaces](contributing-11-4-github-codespaces.md)
 
 # Keep things consistent
 

--- a/apim-lab/11-contributing/contributing-11-1-contribution-guide.md
+++ b/apim-lab/11-contributing/contributing-11-1-contribution-guide.md
@@ -9,7 +9,7 @@ If you'd like to contribute to this workshop, please read the following guidelin
 
 # What Can I Do?
 
-- [Submit an issue or suggestion](contributing-11-2-Submit-issue-suggestion.md)
+- [Submit an issue or suggestion](contributing-11-2-submit-issue-suggestion.md)
 - [Minor update or fix to an existing challenge and adding a new challenge](contributing-11-3-minor-update-fix.md)
 - [Run the github page locally with Github Codespaces](contributing-11-4-github-codespaces.md)
 


### PR DESCRIPTION
This pull request updates internal documentation links in the contribution guide to use consistent file naming conventions. The changes improve clarity and navigation for contributors.

Documentation improvements:

* Updated internal links in `contributing-11-1-contribution-guide.md` to use the `contributing-11-*` file naming pattern for referenced documents, ensuring consistency and easier navigation.