### PR TITLE
Update & Fix Codespaces / DevContainer build

### DIFF
--- a/.devcontainer/.gitattributes
+++ b/.devcontainer/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=2.7-bullseye
+ARG VARIANT=3.2-bookworm
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 WORKDIR /home/
@@ -15,8 +15,11 @@ RUN gem install bundler github-pages
 
 COPY . .
 
+# Convert line endings from CRLF to LF (in case files were edited on Windows)
+RUN sed -i 's/\r$//' ./setup.sh
+
 ENV DEBIAN_FRONTEND=noninteractive
-RUN sh ./setup.sh
+RUN bash ./setup.sh
 
 RUN echo 'export NVM_DIR="$HOME/.nvm"' >> "$HOME/.zshrc"
 RUN echo '\n' >> "$HOME/.zshrc"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,22 @@
 {
     "name": "Codespaces Apim github pages",
-    "extensions": [
-		"vscode-icons-team.vscode-icons",
-        "ms-azuretools.vscode-docker",
-        "ginfuru.ginfuru-vscode-jekyll-syntax"
-    ],
     "dockerFile": "Dockerfile",
-    "settings": {
-        "terminal.integrated.shell.linux": "/usr/bin/zsh",
-    }
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscode-icons-team.vscode-icons",
+                "ms-azuretools.vscode-docker",
+                "ginfuru.ginfuru-vscode-jekyll-syntax"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "rubyLsp.rubyVersionManager": {
+                    "identifier": "none"
+                },
+                "rubyLsp.bundleGemfile": "",
+                "rubyLsp.enabled": false
+            }
+        }
+    },
+    "postCreateCommand": "sudo chmod -R a+w /usr/local/rvm/gems || true && bundle install"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
         {
             "label": "run locally and watch",
             "type": "shell",
-            "command": "bundle exec jekyll serve",
+            "command": "bundle exec jekyll serve --livereload --force_polling",
             "problemMatcher": [],
             "group": {
                 "kind": "build",

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,15 @@ source "https://rubygems.org"
 #     bundle exec jekyll serve
 #
 
-# Enforcing supported github pages versions (Jekyll 3.9.2)
+# Enforcing supported github pages versions (Jekyll 3.9.5)
 # https://pages.github.com/versions/
 gem "jekyll", "	3.9.5"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "just-the-docs"
+
+# Required for Ruby 3.x (webrick was removed from stdlib)
+gem "webrick"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (1.8.0)
     uri (0.13.2)
+    webrick (1.9.2)
 
 PLATFORMS
   x64-mingw-ucrt
@@ -276,6 +277,7 @@ DEPENDENCIES
   jekyll (= 3.9.5)
   just-the-docs
   tzinfo-data
+  webrick
 
 BUNDLED WITH
    2.4.19

--- a/apim-lab/11-contributing/contributing-11-4-github-codespaces.md
+++ b/apim-lab/11-contributing/contributing-11-4-github-codespaces.md
@@ -1,13 +1,15 @@
 ---
-title: Testing changes locally with Github Codespaces
+title: Testing changes locally
 parent: Contributing
 has_children: false
 nav_order: 4
 ---
 
-# Inner loop, testing your changes using Github Codespaces
+# Inner loop, testing your changes
 
-This repo has a github codespace dev container defined, this container is based on ubuntu 20.04 and contains all the libraries and components to run github pages locally in Github Codespaces(ruby 2.7, jekyll, gems, vscode tasks). To test your changes locally do the following:
+## Using Github Codespaces (preferred)
+
+This repo has a github codespace dev container defined, this container is based on Debian Bookworm and contains all the libraries and components to run github pages locally in Github Codespaces (Ruby 3.2, Jekyll, gems, VS Code tasks). To test your changes locally do the following:
 
 - Enable [Github codespaces](https://github.com/features/codespaces) for your account
 - Fork this repo
@@ -26,3 +28,55 @@ This repo has a github codespace dev container defined, this container is based 
 
 
 ![Enabling Codespace](../../assets/gifs/codespace.gif)
+
+## Local Development
+
+You can also run the site locally on your own machine without Github Codespaces. This requires Ruby and Bundler to be installed.
+
+### Prerequisites
+
+- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) (the version compatible with Jekyll 3.9.5)
+- [Bundler](https://bundler.io/) (`gem install bundler`)
+- Git
+
+### Setup
+
+1. Fork and clone the repo:
+
+    ```bash
+    git clone https://github.com/<your-username>/apim-lab.git
+    cd apim-lab
+    ```
+
+2. Install dependencies:
+
+    ```bash
+    bundle install
+    ```
+
+## Running the site with live reload
+
+There are several VS Code tasks defined in `.vscode/tasks.json` you can use, or run the commands directly in a terminal:
+
+- **Build and serve with live reload** (recommended for local development):
+
+    ```bash
+    bundle exec jekyll serve --livereload --force_polling
+    ```
+
+    This starts a local server at `http://localhost:4000` and automatically rebuilds the site when files change.
+
+- **Build only** (no server):
+
+    ```bash
+    bundle exec jekyll build
+    ```
+
+    The generated site will be in the `_site/` directory.
+
+### Folder structure
+
+- `apim-lab/` — Contains all the Markdown documentation files for each lab section
+- `assets/` — Contains all images, slides, and supporting files used in the lab
+- `_config.yml` — Jekyll site configuration
+- `Gemfile` — Ruby dependency definitions


### PR DESCRIPTION
This pull request updates and improves the development container for the project. The most important changes include upgrading the Ruby base image, enforcing consistent line endings, updating shell and Ruby settings, and improving local development workflows.

This PR addresses Issue #159.

**Development container and environment updates:**

* Upgraded the Ruby base image in `.devcontainer/Dockerfile` from `2.7-bullseye` to `3.2-bookworm` for improved compatibility and access to newer Ruby features.
* Added a step in `.devcontainer/Dockerfile` to convert `setup.sh` line endings from CRLF to LF, and ensured shell scripts and Dockerfiles always use LF endings via `.gitattributes` for better cross-platform support. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R18-R22) [[2]](diffhunk://#diff-a6795313111f5898b4c61fc2fbc95a7858a20772f5414c66be17a83941267e7eR1-R3)

**Devcontainer and VS Code customization:**

* Updated `.devcontainer/devcontainer.json` to explicitly set the Dockerfile, customize VS Code extensions and settings (including Ruby LSP options), and add a post-create command to fix gem permissions and run `bundle install`.

**Gem and dependency management:**

* Updated the `Gemfile` to require Jekyll `3.9.5` (from `3.9.2`) and added the `webrick` gem, which is necessary for Ruby 3.x compatibility.

**Development workflow improvements:**

* Modified the "run locally and watch" task in `.vscode/tasks.json` to use `bundle exec jekyll serve --livereload --force_polling`, enabling live reload and more reliable file watching during development.