### PR TITLE
Fix for [Enhancement] Rename Hands-on labs to Guided labs and improve prereqs #153

### DIFF
--- a/.devcontainer/.gitattributes
+++ b/.devcontainer/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=2.7-bullseye
+ARG VARIANT=3.2-bookworm
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 WORKDIR /home/
@@ -15,8 +15,11 @@ RUN gem install bundler github-pages
 
 COPY . .
 
+# Convert line endings from CRLF to LF (in case files were edited on Windows)
+RUN sed -i 's/\r$//' ./setup.sh
+
 ENV DEBIAN_FRONTEND=noninteractive
-RUN sh ./setup.sh
+RUN bash ./setup.sh
 
 RUN echo 'export NVM_DIR="$HOME/.nvm"' >> "$HOME/.zshrc"
 RUN echo '\n' >> "$HOME/.zshrc"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,22 @@
 {
     "name": "Codespaces Apim github pages",
-    "extensions": [
-		"vscode-icons-team.vscode-icons",
-        "ms-azuretools.vscode-docker",
-        "ginfuru.ginfuru-vscode-jekyll-syntax"
-    ],
     "dockerFile": "Dockerfile",
-    "settings": {
-        "terminal.integrated.shell.linux": "/usr/bin/zsh",
-    }
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscode-icons-team.vscode-icons",
+                "ms-azuretools.vscode-docker",
+                "ginfuru.ginfuru-vscode-jekyll-syntax"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "rubyLsp.rubyVersionManager": {
+                    "identifier": "none"
+                },
+                "rubyLsp.bundleGemfile": "",
+                "rubyLsp.enabled": false
+            }
+        }
+    },
+    "postCreateCommand": "sudo chmod -R a+w /usr/local/rvm/gems || true && bundle install"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
         {
             "label": "run locally and watch",
             "type": "shell",
-            "command": "bundle exec jekyll serve",
+            "command": "bundle exec jekyll serve --livereload --force_polling",
             "problemMatcher": [],
             "group": {
                 "kind": "build",

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,15 @@ source "https://rubygems.org"
 #     bundle exec jekyll serve
 #
 
-# Enforcing supported github pages versions (Jekyll 3.9.2)
+# Enforcing supported github pages versions (Jekyll 3.9.5)
 # https://pages.github.com/versions/
 gem "jekyll", "	3.9.5"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "just-the-docs"
+
+# Required for Ruby 3.x (webrick was removed from stdlib)
+gem "webrick"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (1.8.0)
     uri (0.13.2)
+    webrick (1.9.2)
 
 PLATFORMS
   x64-mingw-ucrt
@@ -276,6 +277,7 @@ DEPENDENCIES
   jekyll (= 3.9.5)
   just-the-docs
   tzinfo-data
+  webrick
 
 BUNDLED WITH
    2.4.19

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # About this workshop
 
-This hands-on lab will guide you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security, and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. This is meant to be a hands-on lab experience, all instructions are provided, but a basic level of understanding of apis is expected(http operations, networking basics, openapi, rest, soap, oauth2, and other concepts).
+This guided lab will walk you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security, and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. This is a guided lab experience where all instructions are provided, but a basic level of understanding of APIs is expected (HTTP operations, networking basics, OpenAPI, REST, SOAP, OAuth2, and other concepts).
 
 [This workshop is delivered using Github Pages and Just-The-Docs theme at https://azure.github.io/apim-lab/](https://azure.github.io/apim-lab/)
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,10 +18,10 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: "Azure API Management Hands on Lab"
+title: "Azure API Management Guided Lab"
 #email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
-  This hands-on-lab will guide you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. 
+  This guided lab will walk you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. 
 #baseurl: "" # the subpath of your site, e.g. /blog
 #url: "" # the base hostname & protocol for your site, e.g. http://example.com
 search_enabled: true

--- a/apim-lab/0-prerequisites/prerequisite-0-1-technical.md
+++ b/apim-lab/0-prerequisites/prerequisite-0-1-technical.md
@@ -9,8 +9,9 @@ nav_order: 1
 
 - Azure requirements
   - Access to the [Azure Portal](https://www.portal.azure.com)
-  - Access to an active [Azure subscription](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade)
+  - Access to an active [Azure subscription](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade) - **you must provide your own subscription; Microsoft does not provide free subscriptions for this lab**
   - **Contributor** role in a resource group to be able to deploy an Azure API Management instance
+  - For the Security labs (Authorization Code Flow), you need an account with permissions to **grant admin consent** for API permissions in Microsoft Entra ID
 
 - During this lab, we will add existing APIs to our Azure API Management instance. The following APIs/websites should be available:
   - [Colors API](https://colors-api.azurewebsites.net/swagger/v1/swagger.json), in case this website is down you can deploy your own API using the following [instructions](../10-additional-topics/additional-topics-10-2-container-instance.md)

--- a/apim-lab/1-apim-creation/index.md
+++ b/apim-lab/1-apim-creation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure API Management Creation
 has_children: true
-nav_order: 1
+nav_order: 2
 ---
 
 

--- a/index.markdown
+++ b/index.markdown
@@ -10,7 +10,9 @@ nav_order: 1
 #  About this workshop
 
 
-This hands-on-lab will guide you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. This is meant to be a hands on lab experience, all instructions are provided, but a basic level of understanding of apis is expected(http operations, networking basics, openapi, rest, soap, oauth2 and other concepts).
+This guided lab will walk you through the different concepts around Azure API Management, from the creation to the DevOps, including good practices in terms of versioning, security and so on. It is designed to bring customers and partners to a 200-level understanding of Azure Api Management. This is a guided lab experience where all instructions are provided, but a basic level of understanding of APIs is expected (HTTP operations, networking basics, OpenAPI, REST, SOAP, OAuth2 and other concepts).
+
+> **Important:** Before starting, please review the [Prerequisites](apim-lab/0-prerequisites/) section. You will need your own Azure subscription and an account with appropriate permissions.
 
 [Based on the original Azure API Management Lab by Mark Harrison.](https://github.com/markharrison/Lab_APIM_Original)
 


### PR DESCRIPTION
- Rename 'Hands-on labs' to 'Guided labs' throughout site
- Add link to prerequisites from landing page
- Fix sidebar order: Prerequisites before Creation
- Add admin consent requirement for Security labs

Closes #153
Closes #77